### PR TITLE
cli/print.go: fix print reture bug

### DIFF
--- a/cli/print.go
+++ b/cli/print.go
@@ -15,7 +15,7 @@ func printArts(arts <-chan b.Art, gifMode bool) error {
 	if !gifMode {
 		for art := range arts {
 			for _, v := range art.Content {
-				fmt.Printf("\r%s\n", v)
+				fmt.Println(v)
 			}
 		}
 		return nil


### PR DESCRIPTION
Remove the carriage return from the  line header to format the output character